### PR TITLE
feat: add pagination support (fetch all posts)

### DIFF
--- a/src/utils/get-user-posts.js
+++ b/src/utils/get-user-posts.js
@@ -5,19 +5,21 @@ import { gql, request } from "graphql-request";
  *
  * @export
  * @param {string} username
+ * @param {int} page
  */
-export async function getUserPosts(username) {
+export async function getUserPosts(usernam, pagee) {
   const variables = {
     username,
+    page,
   };
 
   // query information
   const query = gql`
-    query getPosts($username: String!) {
+    query getPosts($username: String!, $page: Int) {
       user(username: $username) {
         publicationDomain
         publication {
-          posts {
+          posts(page: $page) {
             _id
             brief
             contentMarkdown

--- a/src/utils/source-nodes.js
+++ b/src/utils/source-nodes.js
@@ -37,16 +37,14 @@ export async function sourceNodes(
     createNode(hashNodeUser);
 
     // get posts
-    let page = 0;
     let posts = [];
-    while (true) {
-      let nextPage = await getUserPosts(username, page);
+    for (let i = 0; i < 9999; i++) {
+      let nextPage = await getUserPosts(username, i);
 
       if (nextPage.length === 0)
         break;
 
       posts.push(...nextPage);
-      page++;
     }
 
     // process posts

--- a/src/utils/source-nodes.js
+++ b/src/utils/source-nodes.js
@@ -37,7 +37,17 @@ export async function sourceNodes(
     createNode(hashNodeUser);
 
     // get posts
-    const posts = await getUserPosts(username);
+    let page = 0;
+    let posts = [];
+    while (true) {
+      let nextPage = await getUserPosts(username, page);
+
+      if (nextPage.length === 0)
+        break;
+
+      posts.push(...nextPage);
+      page++;
+    }
 
     // process posts
     posts.map((post) => {


### PR DESCRIPTION
# Related Issues
https://github.com/nitzano/gatsby-source-hashnode/issues/12 Support Pagination

closes #12

# Comments
Currently, the plugin is only pulling down the first page of posts (6 posts). This change loops through pages until no more posts are returned.